### PR TITLE
[SERVER] feat: 메세지 전송 로직 수정

### DIFF
--- a/apps/ms-client/app/(root)/(routes)/chat/[roomName]/page.tsx
+++ b/apps/ms-client/app/(root)/(routes)/chat/[roomName]/page.tsx
@@ -93,7 +93,6 @@ const RoomPage = ({
       if (rooms?.length) {
         const newRoomInfo = rooms.find((room) => room.id === roomName)
         if (newRoomInfo) {
-          console.log(newRoomInfo)
           setRoomInfo(() => newRoomInfo)
         }
       }
@@ -162,7 +161,6 @@ const RoomPage = ({
       }
     }
   }, [])
-
   return (
     <>
       <div className="p-3 py-2 hidden sm:block">
@@ -229,16 +227,18 @@ const RoomPage = ({
               />
             </div>
           </div>
-          {messages.map(({ id, message, createdAt, font, userId }, index) => (
-            <ChatBox
-              sender={usersMap[userId]}
-              font={font}
-              content={message}
-              createdAt={createdAt}
-              isMe={id === socket.id}
-              key={id + index + createdAt}
-            />
-          ))}
+          {messages.map(
+            ({ id, userId, message, createdAt, font, user }, index) => (
+              <ChatBox
+                sender={user}
+                font={font}
+                content={message}
+                createdAt={createdAt}
+                isMe={userId === info?.id}
+                key={id + index + createdAt}
+              />
+            ),
+          )}
         </div>
 
         <form

--- a/apps/ms-client/components/lobby.tsx
+++ b/apps/ms-client/components/lobby.tsx
@@ -6,60 +6,6 @@ import { Users } from 'lucide-react'
 import Link from 'next/link'
 import { RoomInfo } from '@/socket'
 
-// 배포환경이 Nodejs 런타임이라 Bun syntax 적용안됨. 임시데이터 추가
-const roomGroupInfo = {
-  '9f8bbd24-9d98-4580-927f-15168791c121': {
-    name: 'Group A',
-    count: 2,
-    title: '가족',
-  },
-  '42b8fb59-c78e-49ff-bfaa-685c590e73c0': {
-    name: 'Group B',
-    count: 3,
-    title: '가족',
-  },
-  'c486c072-5900-4163-8fba-ffa3350a1680': {
-    name: 'Group C',
-    count: 2,
-    title: '연인',
-  },
-  '487b239c-0435-4968-a423-573655a03dbf': {
-    name: 'Group D',
-    count: 2,
-    title: '연인',
-  },
-  '265a5d3b-9dcd-4441-8925-206eb66172e9': {
-    name: 'Group E',
-    count: 2,
-    title: '친구',
-  },
-  'd4152886-a972-496f-8fa7-727026d466e7': {
-    name: 'Group F',
-    count: 3,
-    title: '친구',
-  },
-  '764a41c1-f25d-4cc1-a752-031059e16dd9': {
-    name: 'Group G',
-    count: 2,
-    title: '동료',
-  },
-  '8dbb2e02-5987-4fc2-bab0-37a61881e905': {
-    name: 'Group H',
-    count: 3,
-    title: '동료',
-  },
-  'dfaca612-1b67-4157-8187-2992725d08a9': {
-    name: 'Group I',
-    count: 2,
-    title: '새로운 사람',
-  },
-  '8d828608-bf68-4927-b0b9-12144053728d': {
-    name: 'Group J',
-    count: 3,
-    title: '새로운 사람',
-  },
-}
-
 const LobbyScreen = () => {
   const [rooms, setRooms] = useState<RoomInfo[]>([])
   useSocket({
@@ -68,7 +14,6 @@ const LobbyScreen = () => {
       setRooms(() => newRooms)
     },
   })
-  console.log(rooms, '<<rooms')
 
   return (
     <div

--- a/apps/ms-client/components/user-setting.tsx
+++ b/apps/ms-client/components/user-setting.tsx
@@ -55,9 +55,6 @@ const UserSetting = () => {
   const [activeId, setActiveId] = useState(info?.avatar || '0')
   const { socket } = useSocket({
     nsp: '/',
-    onUserUpdated(user) {
-      setInfo?.(user)
-    },
   })
 
   const onSubmit = (data: UserSettingParams) => {

--- a/apps/ms-client/socket.d.ts
+++ b/apps/ms-client/socket.d.ts
@@ -39,15 +39,12 @@ export interface ReservedMessage {
   message: string
   nickname: string
   font?: Font
+  user: User
 }
 
 interface ServerToClientEvents {
   ROOM_CHANGE: (rooms: RoomInfo[]) => void
-  WELCOME: (userInfo: {
-    id: string
-    nickname: string
-    roomName: string
-  }) => void
+  WELCOME: (user: User) => void
   RESERVE_MESSAGE: (sender: ReservedMessage) => void
   USER_SETTING: (user: User) => void
   [key: `USERS:${string}`]: (users: RoomInfoUser[]) => void

--- a/apps/ms-server/src/chat/chat.gateway.ts
+++ b/apps/ms-server/src/chat/chat.gateway.ts
@@ -20,6 +20,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateMessageDto } from '@/messages/message.dto';
 import { ChatroomsService } from '@/chatrooms/chatrooms.service';
 import { ChatRoomModel } from '@/db/models/chat-room.model';
+import { USER_UNIQUE_KEY } from '@/common/common.constants';
 
 @WebSocketGateway({
   cors: {
@@ -70,7 +71,6 @@ export class ChatGateway
   ) {
     client.join(roomId);
     client.data.roomId = roomId;
-    client.to(roomId).emit('WELCOME', client.data);
     this.serverRoomChange();
     return this.getJoinedUser(roomId);
   }
@@ -88,7 +88,7 @@ export class ChatGateway
   }
 
   @SubscribeMessage('SEND_MESSAGE')
-  async handleSendMEssage(
+  async handleSendMessage(
     @ConnectedSocket() client: Socket,
     @MessageBody() body: SendMessageDto,
   ) {
@@ -114,13 +114,16 @@ export class ChatGateway
 
     this.eventEmitter.emit('message.created', messageCreatedDto);
 
-    this.io.server.to(roomId).emit('RESERVE_MESSAGE', {
-      message,
-      nickname,
-      id: client.id,
-      userId: client.data.user.id,
-      font,
-    });
+    if (client.id && client.data?.user) {
+      this.io.server.to(roomId).emit('RESERVE_MESSAGE', {
+        user: client.data.user,
+        message,
+        nickname,
+        id: client.id,
+        userId: client.data.user.id,
+        font,
+      });
+    }
   }
 
   @SubscribeMessage('USER_SETTING')
@@ -179,9 +182,17 @@ export class ChatGateway
     return this.sentimentsService.getSentimentsByEmotion(emotion);
   }
 
-  handleConnection(@ConnectedSocket() client: Socket) {
+  async handleConnection(@ConnectedSocket() client: Socket) {
+    const userId = client?.handshake?.auth[USER_UNIQUE_KEY];
+    if (!userId) client.disconnect(true);
+    const user = await this.usersService.findUserdById(userId);
+    client.data.user = user;
+
     this.logger.debug(`CONNECTED : ${client.id}`);
     this.logger.debug(`NAMESPACE : ${client.nsp.name}`);
+    client.emit('WELCOME', user);
+    this.serverRoomChange();
+    return user;
   }
 
   handleDisconnect(@ConnectedSocket() client: Socket) {
@@ -190,7 +201,7 @@ export class ChatGateway
     this.io.server.of('/').adapter.del(client.id, client.id);
   }
 
-  private editUserSetting(
+  private async editUserSetting(
     client: Socket,
     editUserDto: { nickname: string; avatar: string },
   ) {

--- a/apps/ms-server/src/chat/types/socket.types.ts
+++ b/apps/ms-server/src/chat/types/socket.types.ts
@@ -2,9 +2,9 @@ import { UserModel } from '@/db/models/user.model';
 import { InferSelectModel } from 'drizzle-orm';
 import { Socket as S } from 'socket.io';
 type Room = string;
-
+export type User = InferSelectModel<typeof UserModel>;
 class SocketData {
-  user: InferSelectModel<typeof UserModel>;
+  user: User;
   roomId: string;
 }
 
@@ -14,6 +14,6 @@ export class Socket extends S<SocketOnEventMap> {
 
 export class SocketOnEventMap {
   JOIN_ROOM: (roomName: string) => Promise<Partial<SocketData>[]>;
-  WELCOME: (userInfo: Socket['data']) => void;
+  WELCOME: (user: User) => void;
   ROOM_CHANGE: (allRooms: Room[]) => void;
 }


### PR DESCRIPTION
- 메세지 주체 socket data -> db select로 변경
- 최초접속 핸들러 onConnect로 변경
- socket auth parameters 추가

## PR 제목
[SERVER] feat: 메세지 전송 로직 수정
## 이슈 번호 및 링크카 있다면 알려주세요.
#29 
## 리뷰 요청 전 확인해주세요.

- [x] 원하는 기능을 구현했습니다.
- [x] 코드 컨벤션에 이상이 없는지 확인했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 추가된 패키지가 있다면 체크해주세요.

- [ ] 새로운 패키지를 추가했습니다.

## 변경 사항에 대해 간단히 설명 해주세요.

아래 수정사항 개발서버 적용했습니다.
메세지 전송 및 확인시 몇가지 변경사항이 있는데요,

`기능적으로`는 

- 메세지에 노출되는 닉네임
기존 : 유저가 바꾼 닉네임 실시간 노출
개선 : 유저가 보낸 시점의 닉네임으로 노출

해당 조치를 통해, 연결이 끊겨 새로접속하는 경우, 아바타 및 닉네임이 사라지지 않고 유지됩니다 
( 모든 말풍선 죄측으로 이동하던 현상 )

개발서버 확인 후 정상으로 판단되실 경우 배포 하겠습니다!


## 수정목록

- 메세지 주체 socket data -> db select로 변경
- 최초접속 핸들러 onConnect로 변경
- socket auth parameters 추가