### PR TITLE
[HOTFIX] feat: 재연결 시 메세지 전송 오류수정

### DIFF
--- a/apps/ms-client/hooks/use-socket.ts
+++ b/apps/ms-client/hooks/use-socket.ts
@@ -84,15 +84,14 @@ const useSocket = ({
     return () => {
       socket.off('connect')
     }
-  }, [isError, onConnect, onRoomChanged, socket])
+  }, [isError, onConnect, onRoomChanged, onUserUpdated, setInfo, socket])
   useEffect(() => {
-    if (socket.connected) {
-      onMounted && onMounted(socket)
-    }
+    onMounted && onMounted(socket)
+
     return () => {
       onUnmounted && onUnmounted(socket)
     }
-  }, [socket.connected])
+  }, [])
   return {
     manager,
     socket: socket,

--- a/apps/ms-server/src/chat/chat.gateway.ts
+++ b/apps/ms-server/src/chat/chat.gateway.ts
@@ -22,7 +22,6 @@ import { ChatroomsService } from '@/chatrooms/chatrooms.service';
 import { ChatRoomModel } from '@/db/models/chat-room.model';
 import { USER_UNIQUE_KEY } from '@/common/common.constants';
 
-
 @WebSocketGateway({
   cors: {
     origin: '*',
@@ -72,7 +71,7 @@ export class ChatGateway
   ) {
     client.join(roomId);
     client.data.roomId = roomId;
-    this.serverRoomChange();
+    await this.serverRoomChange();
     return this.getJoinedUser(roomId);
   }
 


### PR DESCRIPTION
## PR 제목
[HOTFIX] feat: 재연결 시 메세지 전송 오류수정
## 이슈 번호 및 링크카 있다면 알려주세요.
#35 
## 리뷰 요청 전 확인해주세요.

- [x] 원하는 기능을 구현했습니다.
- [x] 코드 컨벤션에 이상이 없는지 확인했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 추가된 패키지가 있다면 체크해주세요.

- [ ] 새로운 패키지를 추가했습니다.

## 변경 사항에 대해 간단히 설명 해주세요.

- Context의 info -> submit dependency 추가
- 방 입장, 퇴장 useEffect 라이프사이클로 전환
- useSocket의 onMounted, onUnmouted 이상 동작으로, 비활성화 후 리액트 라이프사이클 사용